### PR TITLE
Fix listing details when not logged in

### DIFF
--- a/src/pages/__generated__/listing.types.ts
+++ b/src/pages/__generated__/listing.types.ts
@@ -5,7 +5,6 @@ export type GetListingDetailsQueryVariables = GraphQLTypes.Exact<{
 }>;
 
 export type GetListingDetailsQuery = {
-  me: { __typename: "Guest"; id: string } | { __typename: "Host"; id: string };
   listing: {
     __typename: "Listing";
     id: string;
@@ -54,4 +53,8 @@ export type GetListingDetailsQuery = {
       checkOutDate: string;
     } | null>;
   } | null;
+};
+
+export type MeFragment = {
+  me: { __typename: "Guest"; id: string } | { __typename: "Host"; id: string };
 };

--- a/src/pages/listing.tsx
+++ b/src/pages/listing.tsx
@@ -3,10 +3,11 @@ import BookStay from "../components/BookStay";
 import { Center, Divider, Flex, Stack } from "@chakra-ui/react";
 import { GUEST_TRIPS } from "./upcoming-trips";
 import { useParams } from "react-router-dom";
-import { gql, TypedDocumentNode, useQuery } from "@apollo/client";
+import { gql, TypedDocumentNode, useFragment, useQuery } from "@apollo/client";
 import {
   GetListingDetailsQuery,
   GetListingDetailsQueryVariables,
+  MeFragment,
 } from "./__generated__/listing.types";
 import { PageContainer } from "../components/PageContainer";
 import { PageSpinner } from "../components/PageSpinner";
@@ -24,9 +25,6 @@ const LISTING: TypedDocumentNode<
   GetListingDetailsQueryVariables
 > = gql`
   query GetListingDetails($id: ID!) {
-    me {
-      id
-    }
     listing(id: $id) {
       id
       title
@@ -65,13 +63,22 @@ const LISTING: TypedDocumentNode<
   }
 `;
 
+const meFragment = gql`
+  fragment Me on Query {
+    me {
+      id
+    }
+  }
+`;
+
 export function Listing() {
   const { id: idParam } = useParams();
 
   const { data, loading, error } = useQuery(LISTING, {
     variables: { id: idParam! },
   });
-  const user = data?.me;
+  const fragment = useFragment<MeFragment>({ fragment: meFragment, from: {} });
+  const user = fragment.complete ? fragment.data.me : null;
 
   if (loading) {
     return <PageSpinner />;


### PR DESCRIPTION
I was starting to prepare some material to present to my team and I was looking at this workshop.
I know it's not super relevant to update this repo at this point, but I wanted to share why the Listing Details page would crash if you were not logged in.

The `me` query throws an error when you're not logged in.
Because `me { id }` was grouped with the GetListingDetails operation, it would fail the whole query.
I could have done a separate query, but since so many other thing on the site tries to load `me` I figured I'd just look it up in the cache with `useFragment`

End result when user is not logged in
<img width="2484" alt="image" src="https://github.com/user-attachments/assets/3caee317-a7ca-49f6-b3ff-cff90280cc5e">
